### PR TITLE
Change group photo to JPG output

### DIFF
--- a/server/utils/group-photo.js
+++ b/server/utils/group-photo.js
@@ -176,11 +176,10 @@ const createGroupPhotoStream = async (urls) => {
   try {
     const groupPhoto = await createGroupPhoto(urls);
     console.log('Group Photo Processed');
-    const png = await groupPhoto.png({
-      compressionLevel: 5,
-      quality: 100,
+    const output = await groupPhoto.jpeg({
+      quality: 75,
     });
-    await png.toFile('./temp/group-photo.png');
+    await output.toFile('./temp/group-photo.png');
     console.log('Group Photo Output to /temp');
     return fs.createReadStream('./temp/group-photo.png');
   } catch (e) {

--- a/server/utils/group-photo.js
+++ b/server/utils/group-photo.js
@@ -179,9 +179,9 @@ const createGroupPhotoStream = async (urls) => {
     const output = await groupPhoto.jpeg({
       quality: 75,
     });
-    await output.toFile('./temp/group-photo.png');
+    await output.toFile('./temp/group-photo.jpg');
     console.log('Group Photo Output to /temp');
-    return fs.createReadStream('./temp/group-photo.png');
+    return fs.createReadStream('./temp/group-photo.jpg');
   } catch (e) {
     console.log(e);
   }


### PR DESCRIPTION
Updates the outputted [group image to use JPG](https://sharp.pixelplumbing.com/api-output#jpeg), rather than PNG, to reduce file size—previously it was around 9mb for 80 images.