### PR TITLE
abstract branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ If you are using your own S3 instance please provide the following configuration
 
 GIF Booth uses ffmpeg to do video processing, you'll need to have `ffmpeg` installed on your computer. On Heroku we will use the [heroku-buildpack-ffmpeg-latest](https://elements.heroku.com/buildpacks/jonathanong/heroku-buildpack-ffmpeg-latest), more instructions on how to use it on the Deployment section.
 
+
 ### Configuration
 
 Currently, GIF Booth doesn't have an admin interface but it provide an URL endpoint for image moderation, if you want to use this feature please provide the following configuration parameters as environment variables:

--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ If you are using your own S3 instance please provide the following configuration
 
 GIF Booth uses ffmpeg to do video processing, you'll need to have `ffmpeg` installed on your computer. On Heroku we will use the [heroku-buildpack-ffmpeg-latest](https://elements.heroku.com/buildpacks/jonathanong/heroku-buildpack-ffmpeg-latest), more instructions on how to use it on the Deployment section.
 
-
 ### Configuration
 
 Currently, GIF Booth doesn't have an admin interface but it provide an URL endpoint for image moderation, if you want to use this feature please provide the following configuration parameters as environment variables:

--- a/client/src/branding.css
+++ b/client/src/branding.css
@@ -2,7 +2,7 @@
 
 :root {
   --color-primary-100: #ebf8ff;
-  --color-primary-500: #4299E1;
+  --color-primary-500: #4299e1;
   --color-primary-600: #3182ce;
   --color-primary-700: #2b6cb0;
   --color-primary-800: #2c5282;
@@ -13,15 +13,15 @@
 
   --color-secondary-100: #f7fafc;
   --color-secondary-200: #edf2f7;
-  --color-secondary-400: #CBD5E0;
-  --color-secondary-500: #A0AEC0;
+  --color-secondary-400: #cbd5e0;
+  --color-secondary-500: #a0aec0;
   --color-secondary-600: #718096;
-  --color-secondary-700: #4A5568;
+  --color-secondary-700: #4a5568;
 
   --color-background: white;
 
-  --color-error-300: #FEB2B2;
+  --color-error-300: #feb2b2;
   --color-error-500: #f56565;
-  --color-error-600: #E53E3E;
-  --color-error-700: #C53030;
+  --color-error-600: #e53e3e;
+  --color-error-700: #c53030;
 }


### PR DESCRIPTION
- adds readme for customizing coloring and branding images
- abstract css colors to a single css file
- use fostive branding

<img width="529" alt="Screen Shot 2020-09-24 at 8 38 50 PM" src="https://user-images.githubusercontent.com/13678764/94220173-a33d8b80-fea5-11ea-8b35-addf55f80c79.png">
<img width="827" alt="Screen Shot 2020-09-24 at 8 41 19 PM" src="https://user-images.githubusercontent.com/13678764/94220187-a9336c80-fea5-11ea-9137-757d40fdcec0.png">
