### PR TITLE
Add npm run build step for client react app in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Brought to you with 💛 by [Fostive](https://github.com/fostive/).
 ``` bash
 cd client/
 npm install
+npm run build
 ```
 
 ### Server


### PR DESCRIPTION
For `client/build` folder to exist, we need to run `npm run build` in the client react app folder. Otherwise, after running `npm start` locally, we get the error that `client/build/index.html` does not exist. Updated the readme to add the additional step.