### PR TITLE
Fix #2: Remove AWS_BUCKET_URL from env variable & construct url using AWS_BUCKET_NAME

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ If you are using your own S3 instance please provide the following configuration
 * `AWS_REGION`
 * `AWS_SECRET_ACCESS_KEY`
 * `AWS_BUCKET_NAME`
-* `AWS_BUCKET_URL`
 
 #### ffmpeg
 

--- a/config.js
+++ b/config.js
@@ -1,13 +1,14 @@
-'use strict'
-
 const config = {
-  AWS_ACCESS_KEY_ID: process.env.BUCKETEER_AWS_ACCESS_KEY_ID || process.env.AWS_ACCESS_KEY_ID,
+  AWS_ACCESS_KEY_ID:
+    process.env.BUCKETEER_AWS_ACCESS_KEY_ID || process.env.AWS_ACCESS_KEY_ID,
   AWS_REGION: process.env.BUCKETEER_AWS_REGION || process.env.AWS_REGION,
-  AWS_SECRET_ACCESS_KEY: process.env.BUCKETEER_AWS_SECRET_ACCESS_KEY || process.env.AWS_SECRET_ACCESS_KEY,
-  AWS_BUCKET_NAME: process.env.BUCKETEER_BUCKET_NAME || process.env.AWS_BUCKET_NAME,
-  AWS_BUCKET_URL: process.env.BUCKETEER_BUCKET_URL || process.env.AWS_BUCKET_URL,
+  AWS_SECRET_ACCESS_KEY:
+    process.env.BUCKETEER_AWS_SECRET_ACCESS_KEY ||
+    process.env.AWS_SECRET_ACCESS_KEY,
+  AWS_BUCKET_NAME:
+    process.env.BUCKETEER_BUCKET_NAME || process.env.AWS_BUCKET_NAME,
   AUTH_USERNAME: process.env.AUTH_USERNAME || 'admin',
-  AUTH_PASSWORD: process.env.AUTH_PASSWORD
+  AUTH_PASSWORD: process.env.AUTH_PASSWORD,
 }
 
 module.exports = config

--- a/server/server.js
+++ b/server/server.js
@@ -10,7 +10,8 @@ const AWS = require('aws-sdk')
 const config = require('../config')
 const { createGroupPhotoStream } = require('./utils/group-photo')
 
-const makeFileLocation = (file) => `${config.AWS_BUCKET_URL}/${file.Key}`
+const makeFileLocation = (file) =>
+  `https://${config.AWS_BUCKET_NAME}.s3.amazonaws.com/${file.Key}`
 
 const s3 = new AWS.S3({
   accessKeyId: config.AWS_ACCESS_KEY_ID,


### PR DESCRIPTION
Fixes #2 

Heroku bucketeer makes items put in /public/ prefix as public while other's remain private. But all the files in code already assign a public ACL, so we should be good with just removing the URL env var

Also, a pre-commit hook formats the code in config.js which look readable earlier.